### PR TITLE
Accept HTTPS urls, and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 Omas/Omas.egg-info
+*~
+/Omas/uwsgi_params
+*.save

--- a/Omas/api.py
+++ b/Omas/api.py
@@ -93,7 +93,7 @@ app.url_map.converters['beats'] = BeatsConverter
 
 
 def get_external_mei(meipath):
-    pattern_to_strip = r'^/?http(%3A|%3a|:)(%2F|%2f|/)*'
+    pattern_to_strip = r'^/?https?(%3A|%3a|:)(%2F|%2f|/)*'
     meipath_stripped = re.sub(pattern_to_strip, '', meipath, count=1)
     r = requests.get('https://' + unquote(meipath_stripped), timeout=15)
     # Exeunt stage left if something went wrong.


### PR DESCRIPTION
This change fixes the problem with fetching the MEI files from the CRIM site.

Since you're much more familiar with this codebase than I am @mjwalter, I thought I'd ask for your review in case there's something I missed.